### PR TITLE
Fix: updated makefile to docker compose V2 syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 develop: clean build run
 
 build:
-	docker-compose build
+	docker compose build
 
 clean:
-	docker-compose stop -t0
-	docker-compose rm -f
+	docker compose stop -t0
+	docker compose rm -f
 
 run:
-	docker-compose up
+	docker compose up
 
 shell:
-	docker-compose run vue \
+	docker compose run vue \
 		sh


### PR DESCRIPTION
**Description**
Makefile failing due to referencing V1 docker compose
V1 no longer supported by Docker

Issue
Closes #4 